### PR TITLE
Add news pages and archive

### DIFF
--- a/astro/src/components/news/NewsItem.astro
+++ b/astro/src/components/news/NewsItem.astro
@@ -1,0 +1,30 @@
+---
+import type { CollectionEntry } from 'astro:content';
+
+interface Props {
+  post: CollectionEntry<'news'>;
+}
+
+const { post } = Astro.props;
+const date = new Date(post.data.date);
+const year = date.getFullYear();
+const month = String(date.getMonth() + 1).padStart(2, '0');
+const day = String(date.getDate()).padStart(2, '0');
+---
+
+<li>
+  <a href={`/news/${post.slug}/`}>
+    <article class="news-item">
+      <div class="news-item-inner">
+        <div class="date-wrapper">
+          <time datetime={`${year}-${month}-${day}`}>
+            <span class="date">{year}.{month}</span>
+            <span class="day">{day}</span>
+          </time>
+        </div>
+        <p class="text">{post.data.text || post.data.title}</p>
+      </div>
+      <span class="line" />
+    </article>
+  </a>
+</li>

--- a/astro/src/components/news/NewsList.astro
+++ b/astro/src/components/news/NewsList.astro
@@ -1,0 +1,144 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import NewsItem from './NewsItem.astro';
+
+interface Props {
+  posts: CollectionEntry<'news'>[];
+}
+
+const { posts } = Astro.props;
+---
+
+<div class="news-wrapper">
+  <ul class="news-list">
+    {posts.map((post) => (
+      <NewsItem post={post} />
+    ))}
+  </ul>
+</div>
+
+<style lang="scss">
+  @import '@styles/functions.scss';
+  @import '@styles/mixins.scss';
+  .news-wrapper {
+    margin-top: spx(40);
+    @include tablet-up {
+      margin-top: spx(40) * 0.75;
+      padding: 0 10vw;
+    }
+    @include desktop-up {
+      margin-top: ppx(80);
+    }
+  }
+
+  .news-list {
+    width: 100%;
+    background: #fff;
+    box-shadow: 4px 4px 0px 0px #59a1c0;
+    padding: spx(40) spx(20);
+    display: flex;
+    flex-flow: column;
+    gap: spx(10);
+    @include tablet-up {
+      padding: spx(40) * 0.75 spx(20) * 0.75;
+      gap: spx(10) * 0.75;
+    }
+    @include desktop-up {
+      padding: ppx(40) ppx(120);
+      gap: ppx(40);
+    }
+    li {
+      width: 100%;
+      .news-item {
+        display: flex;
+        flex-flow: column;
+        gap: spx(12);
+        width: 100%;
+        @include tablet-up {
+          gap: spx(12) * 0.75;
+        }
+        @include desktop-up {
+          gap: ppx(10);
+        }
+        .news-item-inner {
+          display: flex;
+          align-items: center;
+          gap: spx(28);
+          width: 100%;
+          @include tablet-up {
+            gap: spx(28) * 0.75;
+          }
+          @include desktop-up {
+            gap: ppx(40);
+          }
+          .date-wrapper {
+            time {
+              display: flex;
+              flex-flow: column;
+              align-items: center;
+              width: max-content;
+              .date {
+                color: var(--blue_6, #054965);
+                font-size: spx(12);
+                font-weight: 500;
+                line-height: 100%;
+                letter-spacing: spx(0.6);
+
+                @include tablet-up {
+                  font-size: spx(12) * 0.75;
+                  letter-spacing: spx(0.6) * 0.75;
+                }
+
+                @include desktop-up {
+                  font-size: ppx(14);
+                  letter-spacing: ppx(0.7);
+                }
+              }
+              .day {
+                font-size: spx(38);
+                font-weight: 500;
+                line-height: 100%;
+                letter-spacing: spx(1.9);
+
+                @include tablet-up {
+                  font-size: spx(38) * 0.75;
+                  letter-spacing: spx(1.9) * 0.75;
+                }
+
+                @include desktop-up {
+                  font-size: ppx(40);
+                  letter-spacing: ppx(2);
+                }
+              }
+            }
+          }
+          .text {
+            font-size: spx(14);
+            font-weight: 500;
+            line-height: 140%;
+            letter-spacing: spx(-0.7);
+            width: 100%;
+
+            @include tablet-up {
+              font-size: spx(14) * 0.75;
+              letter-spacing: spx(-0.7) * 0.75;
+              width: 64vw;
+            }
+
+            @include desktop-up {
+              font-size: ppx(18);
+              letter-spacing: ppx(-0.9);
+              width: ppx(685);
+            }
+          }
+        }
+        .line {
+          display: block;
+          width: 100%;
+          height: 2px;
+          background-color: #59a1c0;
+        }
+      }
+    }
+  }
+</style>

--- a/astro/src/components/toppage/ToppageSectionNews.astro
+++ b/astro/src/components/toppage/ToppageSectionNews.astro
@@ -39,7 +39,7 @@ const limitedPosts = sortedPosts.slice(0, limit);
 
           return (
             <li>
-              <a href="#">
+              <a href={`/news/${post.slug}/`}>
                 <article class="news-item">
                   <div class="news-item-inner">
                     <div class="date-wrapper">
@@ -63,7 +63,7 @@ const limitedPosts = sortedPosts.slice(0, limit);
   </div>
 
   <div class="btn-wrapper">
-    <PrimaryButton href="#" title="お知らせ一覧" />
+    <PrimaryButton href="/news/" title="お知らせ一覧" />
   </div>
 </section>
 

--- a/astro/src/data/navigation.ts
+++ b/astro/src/data/navigation.ts
@@ -5,7 +5,7 @@ export const mainNavigation = [
   { label: '社員紹介', url: '/people' },
   { label: '働く環境', url: '/culture' },
   { label: '選考フロー', url: '/flow' },
-  { label: 'お知らせ', url: '/' },
+  { label: 'お知らせ', url: '/news' },
   { label: '求人', url: '/jobs' },
   { label: '新卒の方', url: '/new-graduate' },
   { label: '中途の方', url: '/mid-career' },

--- a/astro/src/pages/news/[slug].astro
+++ b/astro/src/pages/news/[slug].astro
@@ -1,0 +1,88 @@
+---
+import MySiteLayout from '@layouts/MySiteLayout.astro';
+import LowerPageHeader from '@components/common/LowerPageHeader.astro';
+import { getEntryBySlug } from 'astro:content';
+
+const { slug } = Astro.params;
+const post = await getEntryBySlug('news', slug);
+if (!post) {
+  throw new Error(`Post not found: ${slug}`);
+}
+const { Content } = await post.render();
+const date = new Date(post.data.date);
+const year = date.getFullYear();
+const month = String(date.getMonth() + 1).padStart(2, '0');
+const day = String(date.getDate()).padStart(2, '0');
+---
+
+<MySiteLayout>
+  <LowerPageHeader pageTitleEn="News" pageTitleJa="お知らせ" />
+  <article class="news-detail">
+    <div class="date-wrapper">
+      <time datetime={`${year}-${month}-${day}`}>
+        {year}.{month}.{day}
+      </time>
+      {post.data.category && <span class="category">{post.data.category}</span>}
+    </div>
+    <h2 class="title">{post.data.title}</h2>
+    <Content />
+  </article>
+</MySiteLayout>
+
+<style lang="scss">
+  @import '@styles/functions.scss';
+  @import '@styles/mixins.scss';
+  .news-detail {
+    padding: spx(40) spx(20);
+    @include tablet-up {
+      padding: spx(40) * 0.75 spx(20) * 0.75;
+    }
+    @include desktop-up {
+      padding: ppx(100) ppx(160);
+    }
+    .date-wrapper {
+      display: flex;
+      gap: spx(12);
+      margin-bottom: spx(20);
+      @include tablet-up {
+        gap: spx(12) * 0.75;
+        margin-bottom: spx(20) * 0.75;
+      }
+      @include desktop-up {
+        gap: ppx(20);
+        margin-bottom: ppx(40);
+      }
+      time {
+        font-size: spx(14);
+        @include tablet-up {
+          font-size: spx(14) * 0.75;
+        }
+        @include desktop-up {
+          font-size: ppx(18);
+        }
+      }
+      .category {
+        font-size: spx(14);
+        @include tablet-up {
+          font-size: spx(14) * 0.75;
+        }
+        @include desktop-up {
+          font-size: ppx(18);
+        }
+      }
+    }
+    .title {
+      font-size: spx(20);
+      font-weight: 700;
+      margin-bottom: spx(20);
+      @include tablet-up {
+        font-size: spx(20) * 0.75;
+        margin-bottom: spx(20) * 0.75;
+      }
+      @include desktop-up {
+        font-size: ppx(28);
+        margin-bottom: ppx(40);
+      }
+    }
+  }
+</style>

--- a/astro/src/pages/news/index.astro
+++ b/astro/src/pages/news/index.astro
@@ -1,0 +1,15 @@
+---
+import MySiteLayout from '@layouts/MySiteLayout.astro';
+import LowerPageHeader from '@components/common/LowerPageHeader.astro';
+import NewsList from '@components/news/NewsList.astro';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('news')).sort(
+  (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
+);
+---
+
+<MySiteLayout>
+  <LowerPageHeader pageTitleEn="News" pageTitleJa="お知らせ" />
+  <NewsList posts={posts} />
+</MySiteLayout>

--- a/astro/src/utils/navigation.ts
+++ b/astro/src/utils/navigation.ts
@@ -6,6 +6,7 @@ export function getPageTitle(segment: string): string {
     culture: '働く環境',
     jobs: '求人',
     flow: '選考フロー',
+    news: 'お知らせ',
     faq: 'よくある質問',
     new_graduate: '新卒の方',
     mid_career: '中途の方',


### PR DESCRIPTION
## Summary
- implement dynamic news detail page and archive list
- create reusable `NewsList` and `NewsItem` components
- wire homepage news links to point at new pages
- add news to navigation helpers

## Testing
- `npm run build` *(fails: astro not found)*