### PR TITLE
Fix pagination links

### DIFF
--- a/astro/src/components/common/Pagination.astro
+++ b/astro/src/components/common/Pagination.astro
@@ -42,7 +42,9 @@ const pageNumbers = getPageNumbers(currentPage, totalPages);
     <li>
       <a
         href={currentPage > 1
-          ? `${baseUrl}?page=${currentPage - 1}`
+          ? currentPage - 1 === 1
+            ? '/news/'
+            : `${baseUrl}/${currentPage - 1}/`
           : undefined}
         aria-disabled={currentPage === 1}
         class="arrow"
@@ -69,7 +71,7 @@ const pageNumbers = getPageNumbers(currentPage, totalPages);
     <li>
       <a
         href={currentPage < totalPages
-          ? `${baseUrl}?page=${currentPage + 1}`
+          ? `${baseUrl}/${currentPage + 1}/`
           : undefined}
         aria-disabled={currentPage === totalPages}
         class="arrow"

--- a/astro/src/pages/news/index.astro
+++ b/astro/src/pages/news/index.astro
@@ -5,7 +5,7 @@ import NewsList from '@components/news/NewsList.astro';
 import Pagination from '@components/common/Pagination.astro';
 import { getCollection } from 'astro:content';
 
-const POSTS_PER_PAGE = 1;
+const POSTS_PER_PAGE = 10;
 const currentPage = 1;
 
 const allPosts = (await getCollection('news')).sort(


### PR DESCRIPTION
## Summary
- fix pagination arrow links to not use query params
- use 10 posts per page on the news index

## Testing
- `npm install` *(fails: `Exit handler never called`)*